### PR TITLE
Leave ignored files intact

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,14 @@ function plugin(options){
 			if (!options.force && relativeFromCwd.substr(0,2) === '..') {
 				callback(new gPluginError('Delete outside of CWD NOT supported. To enable -> {force:true}: "' + file.revOrigPath + '"'));
 			} else {
-				rimraf(file.revOrigPath, rimrafHandler);
+				if(file.revOrigPath !== file.path){
+					rimraf(file.revOrigPath, rimrafHandler);	
+				}
+				
+				else{
+					callback();
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
There are options with gulp-rev-all that allow you to not rename files. These files were being deleted by this plugin, but we should leave them in place.
